### PR TITLE
FEM-2685 Added primary and fallback title in the getTitle function.

### DIFF
--- a/Sources/PKYouboraPlayerAdapter.swift
+++ b/Sources/PKYouboraPlayerAdapter.swift
@@ -83,7 +83,11 @@ extension PKYouboraPlayerAdapter {
     }
     
     override func getTitle() -> String? {
-        return player?.mediaEntry?.id ?? super.getTitle()
+        if let name = player?.mediaEntry?.name {
+            return name
+        } else {
+            return player?.mediaEntry?.id ?? super.getTitle()
+        }
     }
     
     override func getPlayhead() -> NSNumber? {


### PR DESCRIPTION
Updated the getTitle function in the PlayerAdapter to return the mediaEntry name and if it doesn't have a name then the mediaEntry id.