### PR TITLE
FEC-10431 Support iOS 14 Xcode 12

### DIFF
--- a/Sources/YouboraConfig.swift
+++ b/Sources/YouboraConfig.swift
@@ -12,7 +12,7 @@ struct YouboraConfig: Decodable {
     let username: String?
     let userType: String?
     let obfuscateIP: Bool?
-    let httpSecure: Bool? = true
+    var httpSecure: Bool? = true
     
     let media: Media?
     let ads: Ads?


### PR DESCRIPTION
Fixed warning, Immutable property will not be decoded because it is declared with an initial value which cannot be overwritten.
