### PR TITLE
FEC-10434 PlayKitYoubora app name parameter for iOS

### DIFF
--- a/Sources/YouboraConfig.swift
+++ b/Sources/YouboraConfig.swift
@@ -19,6 +19,7 @@ struct YouboraConfig: Decodable {
     let properties: Properties?
     let extraParams: ExtraParams?
     let houseHoldId: String?
+    let appName: String?
 
     func options() -> YBOptions {
         let options = YBOptions()
@@ -94,6 +95,10 @@ struct YouboraConfig: Decodable {
             options.contentCustomDimension8 = extraParams.param8
             options.contentCustomDimension9 = extraParams.param9
             options.contentCustomDimension10 = extraParams.param10
+        }
+        
+        if let appName = appName {
+            options.appName = appName
         }
         
         return options

--- a/Sources/YouboraPlugin.swift
+++ b/Sources/YouboraPlugin.swift
@@ -69,7 +69,7 @@ public class YouboraPlugin: BasePlugin, AppStateObservable {
         
         PKLog.debug("Start monitoring Youbora")
         
-        YBLog.debugLevel()
+        YBLog.setDebugLevel(.debug)
         
         ybPlugin = YBPlugin(options: youboraConfig?.options(), andAdapter: pkYouboraPlayerAdapter)
         ybPlugin?.adsAdapter = pkYouboraAdsAdapter


### PR DESCRIPTION
Added appName to the config.
Fixed code which called to get the YBLog debugLevel and doing nothing with it, instead of setting it to debug level.

Solves FEC-10434