### PR TITLE
FEC-10270 Fixes in value format for Youbora playhead and adPlayhead.

### DIFF
--- a/Sources/PKYouboraAdsAdapter.swift
+++ b/Sources/PKYouboraAdsAdapter.swift
@@ -63,7 +63,7 @@ extension PKYouboraAdsAdapter {
     
     override func getPlayhead() -> NSNumber? {
         if let adPlayhead = self.adPlayhead, adPlayhead > 0 {
-            return NSNumber(value: adPlayhead)
+            return NSNumber(value: Float(round(100 * adPlayhead)/100))
         } else {
             return super.getPlayhead()
         }

--- a/Sources/PKYouboraPlayerAdapter.swift
+++ b/Sources/PKYouboraPlayerAdapter.swift
@@ -101,7 +101,7 @@ extension PKYouboraPlayerAdapter {
         
         let currentTime = player.currentTime
         
-        return NSNumber(value: currentTime)
+        return NSNumber(value: Float(round(100 * currentTime)/100))
     }
     
     override func getPlayerVersion() -> String? {


### PR DESCRIPTION
FEC-10270 Fixes in value format for Youbora playhead and adPlayhead. Up to two places after decimal point.