### PR TITLE
FEC-11643 Rendition values are not reported on start event.

### DIFF
--- a/Sources/PKYouboraAdsAdapter.swift
+++ b/Sources/PKYouboraAdsAdapter.swift
@@ -156,6 +156,7 @@ extension PKYouboraAdsAdapter {
                     guard let self = self else { return }
                     // Update ad info with the new loaded event
                     self.adInfo = event.adInfo
+                    self.plugin?.fireInit()
                 }
             case let e where e.self == AdEvent.adStarted:
                 messageBus.addObserver(self, events: [e.self]) { [weak self] event in

--- a/Sources/PKYouboraPlayerAdapter.swift
+++ b/Sources/PKYouboraPlayerAdapter.swift
@@ -194,9 +194,7 @@ extension PKYouboraPlayerAdapter {
             
             switch event {
             case is PlayerEvent.Play:
-                // Play handler to start when asset starts loading.
-                // This point is the closest point to prepare call.
-                self.fireStart()
+                self.plugin?.fireInit()
                 self.postEventLog(withMessage: "\(event.namespace)")
             case is PlayerEvent.Stopped:
                 // We must call `fireStop()` when stopped so youbora will know player stopped playing content.
@@ -207,10 +205,12 @@ extension PKYouboraPlayerAdapter {
                 self.firePause()
                 self.postEventLog(withMessage: "\(event.namespace)")
             case is PlayerEvent.Playing:
-                self.fireJoin()
                 if self.isFirstPlay {
                     self.isFirstPlay = false
+                    self.fireStart()
+                    self.fireJoin()
                 } else {
+                    self.fireJoin()
                     self.fireResume()
                 }
                 self.postEventLog(withMessage: "\(String(describing: event.namespace))")


### PR DESCRIPTION
Added fireInit in order for the rendition to appear in fireStart.

Solves FEC-11643